### PR TITLE
allow using onetime >= 2.0 (instead of ^2.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "command-line"
   ],
   "dependencies": {
-    "onetime": "^2.0.0",
+    "onetime": ">= 2.0.0",
     "signal-exit": "^3.0.2"
   }
 }


### PR DESCRIPTION
The latest version of onetime is 5.0 (of course, you know).

https://github.com/sindresorhus/onetime