### PR TITLE
do not print control code to non-terminals

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,10 +2,14 @@ import process from 'node:process';
 import onetime from 'onetime';
 import signalExit from 'signal-exit';
 
-const restoreCursor = onetime(() => {
+const terminal = process.stderr.isTTY ? process.stderr :
+	process.stdout.isTTY ? process.stdout :
+		null;
+
+const restoreCursor = terminal ? onetime(() => {
 	signalExit(() => {
-		process.stderr.write('\u001B[?25h');
+		terminal.write('\u001B[?25h');
 	}, {alwaysLast: true});
-});
+}) : () => {};
 
 export default restoreCursor;

--- a/index.test.mjs
+++ b/index.test.mjs
@@ -1,0 +1,60 @@
+import { test } from "node:test";
+import assert from "node:assert";
+import { spawnSync } from "node:child_process";
+import os from "node:os";
+import { unlinkSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const res = path => new URL(path, import.meta.url);
+const module = res("./index.js");
+
+const file = fileURLToPath(res(os.tmpdir + "/test.mjs"));
+const script = `
+if (process.argv[2] === "1") process.stdout.isTTY = true;
+if (process.argv[3] === "1") process.stderr.isTTY = true;
+// affordance for node 16 bug.
+process.stderr.hasColors = () => false;
+await import(${JSON.stringify(module)}).then(({default: restoreCursor}) => {
+	restoreCursor();
+});
+delete process.stdout.isTTY;
+delete process.stderr.isTTY;
+`;
+const restoreCode = "\u001B[?25h";
+
+test("write test script", async () => {
+	writeFileSync(file, script);
+});
+
+test("stdout tty, stderr not, write to stdout", async () => {
+	const result = spawnSync(process.execPath, [file, "1", "0"], {
+		encoding: "utf8"
+	});
+	assert.equal(result.status, 0);
+	assert.deepStrictEqual([result.stdout, result.stderr], [restoreCode, ""]);
+});
+
+test("stderr tty, stdout not, write to stderr", async () => {
+	const result = spawnSync(process.execPath, [file, "0", "1"], {
+		encoding: "utf8"
+	});
+	assert.deepStrictEqual([result.stdout, result.stderr], ["", restoreCode]);
+});
+
+test("both tty, write to stderr", async () => {
+	const result = spawnSync(process.execPath, [file, "1", "1"], {
+		encoding: "utf8"
+	});
+	assert.deepStrictEqual([result.stdout, result.stderr], ["", restoreCode]);
+});
+
+test("neither tty, write nowhere", async () => {
+	const result = spawnSync(process.execPath, [file, "0", "0"], {
+		encoding: "utf8"
+	});
+	assert.deepStrictEqual([result.stdout, result.stderr], ["", ""]);
+});
+
+test("remove test script", () => {
+	unlinkSync(file);
+});

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 		"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
 	},
 	"scripts": {
-		"test": "xo && tsd"
+		"test": "xo && tsd && node --test index.test.mjs"
 	},
 	"files": [
 		"index.js",


### PR DESCRIPTION
This avoids all the `25h` lines getting printed on GitHub Actions, which does support colors, but does not support ANSI cursor control codes.

If the terminal is not a tty, then there's no cursor to show or hide.

Also, prevents printing the control code to stderr if stdout is a terminal and stderr isn't, and vice versa, for the same reason.